### PR TITLE
BREAKING CHANGE: Everything is a promise now.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "front-matter": "^4.0.2",
     "glob": "^8.0.3",
     "marked": "^4.2.2",
-    "tyrdb": "^4.0.0-beta.1"
+    "picodb": "^1.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "excerpt-html": "^1.2.2",
     "front-matter": "^4.0.2",
     "glob": "^8.0.3",
-    "marked": "^4.2.2"
+    "marked": "^4.2.2",
+    "tyrdb": "^4.0.0-beta.1"
   }
 }

--- a/src/fileWalker.ts
+++ b/src/fileWalker.ts
@@ -1,0 +1,44 @@
+import { ContentItem, ContentItemType, toContentItem } from "./ContentItem";
+import { getFMData } from "./front-matter";
+import { GetSlug } from "./typedefs";
+import { glob as callbackGlob } from "glob";
+import fs from "node:fs/promises";
+import { promisify } from "util";
+
+const glob = promisify(callbackGlob);
+
+interface FileWalkerArgs {
+  globPattern: string;
+  getSlug: GetSlug;
+  type: ContentItemType;
+}
+
+export const fileWalker = async (args: FileWalkerArgs): Promise<ContentItem[]> => {
+  const {
+    globPattern,
+    getSlug,
+    type,
+  } = args;
+  const filePaths = await glob(globPattern);
+  const items = [];
+  for (const filePath of filePaths) {
+    const stats = await fs.stat(filePath);
+    if (!stats.isFile()) {
+      continue;
+    }
+
+    const markdown = (await fs.readFile(filePath)).toString();
+    const fmData = getFMData({ markdown, filePath });
+    const item = toContentItem({
+      filePath,
+      stats,
+      fmData,
+      getSlug,
+      type,
+    });
+
+    items.push(item);
+  }
+
+  return items;
+};

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,7 @@
 import { getPatrika } from ".";
 import assert from "assert";
 
+// TODO: Have more tests beyond just adhering to the interface (which TS checks anyway).
 describe("getPatrika", () => {
   it("should return an instance of Patrika", async () => {
     const patrika = await getPatrika({

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,7 @@ export async function getPatrika (args: GetPatrikaArgs): Promise<Patrika> {
     getPages: () => db.find({ type: ContentItemType.Page }).toArray(),
     getPosts: () => db.find({ type: ContentItemType.Post }).toArray(),
     getTags: () => tagsMap,
+    find: (query: Record<string, any>) => db.find(query).toArray(),
     /// @ts-expect-error Doing a `?? []` here would potentially hide bugs in case something changes between populating and delivering map values.
     getPostsForTag: (tag: string) => tagsMap.get(tag),
   };

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -33,7 +33,7 @@ export const renderAllMarkdown = async (args: RenderAllMarkdownArgs): Promise<vo
 
   marked.use(...getExtensions({ getPostData }));
 
-  for (const item of patrika.getAll()) {
+  for (const item of (await patrika.getAll())) {
     item.body = await marked(item.markdown);
     item.excerpt = {};
     for (const excerptVariant in excerpts) {

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -13,5 +13,6 @@ export interface Patrika {
   getById(id: string): Promise<ContentItem|undefined>;
   getPages(): Promise<ContentItem[]>;
   getPosts(): Promise<ContentItem[]>;
+  find: (query: Record<string, any>) => Promise<ContentItem[]>;
   getTags(): Record<string, ContentItem[]>;
 }

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -9,9 +9,9 @@ interface GetSlugArgs {
 export type GetSlug = (args: GetSlugArgs) => string;
 
 export interface Patrika {
-  getAll(): ContentItem[];
-  getById(id: string): ContentItem|undefined;
-  getPages(): ContentItem[];
-  getPosts(): ContentItem[];
+  getAll(): Promise<ContentItem[]>;
+  getById(id: string): Promise<ContentItem|undefined>;
+  getPages(): Promise<ContentItem[]>;
+  getPosts(): Promise<ContentItem[]>;
   getTags(): Record<string, ContentItem[]>;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,14 +3,14 @@
   "compilerOptions": {
     "sourceMap": true,
     "outDir": "lib",
-    "lib": [
-      "ES6"
-    ]
+    "lib": ["ES6"],
+    "moduleResolution": "Node16",
+    "typeRoots": ["./node_modules/@types", "./types"],
   },
   "include": [
     "./src/**/*"
   ],
   "exclude": [
-    "./src/**/*.test.ts"
+    "./src/**/*.test.ts", "node_modules"
   ]
 }

--- a/types/picodb/index.d.ts
+++ b/types/picodb/index.d.ts
@@ -1,0 +1,28 @@
+/***
+ * @see https://www.npmjs.com/package/picodb
+ */
+
+declare module "picodb" {
+  type Query = Record<string, unknown>;
+  type Callback = () => void;
+  interface ReturnedCollection<DocumentType> {
+    toArray: () => Promise<DocumentType[]>;
+  }
+
+  // eslint-disable-next-line import/no-default-export
+  export default class PicoDB<DocumentType> {
+    constructor ();
+    count: () => Promise<number>;
+    deleteMany: (query: Query) => Promise<void>;
+    deleteOne: (query: Query) => Promise<void>;
+    insertMany: (data: DocumentType[]) => Promise<DocumentType[]>;
+    insertOne: (data: DocumentType) => Promise<DocumentType>;
+    updateMany: (query: Query, data: DocumentType) => Promise<DocumentType[]>;
+    updateOne: (query: Query, data: DocumentType) => Promise<DocumentType>;
+    find: (query: Query) => ReturnedCollection<DocumentType>;
+    toArray: () => Promise<DocumentType[]>;
+    on: (eventName: string, Callback) => Promise<void>;
+    one: (eventName: string, Callback) => Promise<Record<string, unknown>>;
+    off: (eventName: string, Callback) => Promise<void>;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1779,6 +1779,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+eventemitter2@^6.4.9:
+  version "6.4.9"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.9.tgz#41f2750781b4230ed58827bc119d293471ecb125"
+  integrity sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==
+
 excerpt-html@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/excerpt-html/-/excerpt-html-1.2.2.tgz#3a9531e386ae5e7dbeb69d58cbbc1790e7d0cc9d"
@@ -1932,6 +1937,11 @@ fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
+fslockjs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/fslockjs/-/fslockjs-3.0.0.tgz#dae049fad2bb1dcfa6d0a230ea42efd82cb9b0c4"
+  integrity sha512-U0qwKJVHsZ/edyZ0vO3QCz7FoQdiaH5BfIx9Izboc9YnLAMEIj7AG99weKJOwYx/UqdU+txi9iXOkF1wNG6iZA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -2911,6 +2921,16 @@ lodash.bind@^4.1.4:
   resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
   integrity sha512-lxdsn7xxlCymgLYo1gGvVrfHmkjDiyqVv62FAeF2i5ta72BipE1SLxw8hPEPLhD4/247Ijw07UQH7Hq/chT5LA==
 
+lodash.clone@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
+  integrity sha512-GhrVeweiTD6uTmmn5hV/lzgCQhccwReIVRLHp7LT4SopOjqEZ5BbX8b5WWEtAKasjmy8hR7ZPwsYlxRCku5odg==
+
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
 lodash.defaults@^4.0.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
@@ -2921,20 +2941,50 @@ lodash.filter@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
   integrity sha512-pXYUy7PR8BCLwX5mgJ/aNtyOvuJTdZAo9EQFUvMIYugqmJxnrYaANvTbgndOzHSCSR0wnlBBfRXJL5SbWxo3FQ==
 
+lodash.find@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
+  integrity sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==
+
 lodash.flatten@^4.2.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==
 
-lodash.foreach@^4.3.0:
+lodash.foreach@^4.3.0, lodash.foreach@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
   integrity sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ==
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
+
+lodash.intersection@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.intersection/-/lodash.intersection-4.4.0.tgz#0a11ba631d0e95c23c7f2f4cbb9a692ed178e705"
+  integrity sha512-N+L0cCfnqMv6mxXtSPeKt+IavbOBBSiAEkKyLasZ8BVcP9YXQgxLO12oPR8OyURwKV8l5vJKiE1M8aS70heuMg==
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
+
+lodash.isobject@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
+  integrity sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==
 
 lodash.map@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
   integrity sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==
+
+lodash.matches@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.matches/-/lodash.matches-4.6.0.tgz#ae1affba8047f02368905fe585376bd2c10aaf5e"
+  integrity sha512-itQFfvxQETfkYkqZwUCvYXTSO9hyJuC/pUG3ckz8c5ioDR4gYfK117Bza6bKRRxB1MAX0Aezj79tqL3zINCiRA==
 
 lodash.memoize@4.x:
   version "4.1.2"
@@ -2951,7 +3001,12 @@ lodash.pick@^4.2.1:
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==
 
-lodash.reduce@^4.4.0:
+lodash.range@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.range/-/lodash.range-3.2.0.tgz#f461e588f66683f7eadeade513e38a69a565a15d"
+  integrity sha512-Fgkb7SinmuzqgIhNhAElo0BL/R1rHCnhwSZf78omqSwvWqD0kD2ssOAutQonDKH/ldS8BxA72ORYI09qAY9CYg==
+
+lodash.reduce@^4.4.0, lodash.reduce@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
   integrity sha512-6raRe2vxCYBhpBu+B+TtNGUzah+hQjVdu3E17wfusjyrXBka2nBS8OH/gjVZ5PvHOhWmIZTYri09Z6n/QfnNMw==
@@ -2965,6 +3020,11 @@ lodash.some@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
   integrity sha512-j7MJE+TuT51q9ggt4fSgVqro163BEFjAt3u97IqU+JA2DkWl80nFTrowzLpZ/BnpN7rrl0JA/593NAdd8p/scQ==
+
+lodash.transform@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.transform/-/lodash.transform-4.6.0.tgz#12306422f63324aed8483d3f38332b5f670547a0"
+  integrity sha512-LO37ZnhmBVx0GvOU/caQuipEh4GN82TcWv3yHlebGDgOxbxiwwzW5Pcx2AcvpIv2WmvmSMoC492yQFNhy/l/UQ==
 
 lodash.truncate@^4.4.2:
   version "4.4.2"
@@ -3111,6 +3171,11 @@ mocha@^10.1.0:
     yargs "16.2.0"
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
+
+mongo-objectid@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/mongo-objectid/-/mongo-objectid-1.2.2.tgz#1905eefca5c068b3bcb06685aed92ab201a243a4"
+  integrity sha512-tgpARlHojuPmCIr+NFke8iShAH342zqpG7H3bUTXImj8z9eOtsGYcgneeFKDLsrlIi/ZJi9r18Wsr1dSwTLlWQ==
 
 ms@2.1.2:
   version "2.1.2"
@@ -3502,6 +3567,23 @@ safe-regex-test@^1.0.0:
     get-intrinsic "^1.1.3"
     is-regex "^1.1.4"
 
+sbtree@^4.0.0-beta.1:
+  version "4.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/sbtree/-/sbtree-4.0.0-beta.1.tgz#5f99338e1abff209c4ae28c98c7893aa473eb6c7"
+  integrity sha512-rdQFk9qlWfMja2Xgbinvobo+Snb/tmjLHt6FQk9l64jtJxegiHrlvmZE+w90yhis4b2TmVoCLy/CG2bxKfHVvQ==
+  dependencies:
+    fslockjs "^3.0.0"
+    lodash.clonedeep "^4.5.0"
+    lodash.foreach "^4.5.0"
+    lodash.get "^4.4.2"
+    lodash.intersection "^4.4.0"
+    lodash.isequal "^4.5.0"
+    lodash.isobject "^3.0.2"
+    lodash.range "^3.2.0"
+    lodash.reduce "^4.6.0"
+    lodash.transform "^4.6.0"
+    mongo-objectid "^1.2.2"
+
 semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
@@ -3879,6 +3961,21 @@ typescript@^4.8.4:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+tyrdb@^4.0.0-beta.1:
+  version "4.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/tyrdb/-/tyrdb-4.0.0-beta.1.tgz#2dc892c235c8e08e7f42624044a9876172a6a889"
+  integrity sha512-NvJ+s+Eqc/4M/MYKg/HWgQRd/AwPxZan7LIQqZF4GV0lOczt04SrJNBrywvhWg7syIYDAhjbjnD3cH6RUqTnsw==
+  dependencies:
+    eventemitter2 "^6.4.9"
+    fslockjs "^3.0.0"
+    lodash.clone "^4.5.0"
+    lodash.find "^4.6.0"
+    lodash.foreach "^4.5.0"
+    lodash.matches "^4.6.0"
+    lodash.reduce "^4.6.0"
+    mongo-objectid "^1.2.2"
+    sbtree "^4.0.0-beta.1"
 
 unbox-primitive@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1779,11 +1779,6 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-eventemitter2@^6.4.9:
-  version "6.4.9"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.9.tgz#41f2750781b4230ed58827bc119d293471ecb125"
-  integrity sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==
-
 excerpt-html@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/excerpt-html/-/excerpt-html-1.2.2.tgz#3a9531e386ae5e7dbeb69d58cbbc1790e7d0cc9d"
@@ -1937,11 +1932,6 @@ fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
-fslockjs@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/fslockjs/-/fslockjs-3.0.0.tgz#dae049fad2bb1dcfa6d0a230ea42efd82cb9b0c4"
-  integrity sha512-U0qwKJVHsZ/edyZ0vO3QCz7FoQdiaH5BfIx9Izboc9YnLAMEIj7AG99weKJOwYx/UqdU+txi9iXOkF1wNG6iZA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -2921,16 +2911,6 @@ lodash.bind@^4.1.4:
   resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
   integrity sha512-lxdsn7xxlCymgLYo1gGvVrfHmkjDiyqVv62FAeF2i5ta72BipE1SLxw8hPEPLhD4/247Ijw07UQH7Hq/chT5LA==
 
-lodash.clone@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
-  integrity sha512-GhrVeweiTD6uTmmn5hV/lzgCQhccwReIVRLHp7LT4SopOjqEZ5BbX8b5WWEtAKasjmy8hR7ZPwsYlxRCku5odg==
-
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
-
 lodash.defaults@^4.0.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
@@ -2941,50 +2921,20 @@ lodash.filter@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
   integrity sha512-pXYUy7PR8BCLwX5mgJ/aNtyOvuJTdZAo9EQFUvMIYugqmJxnrYaANvTbgndOzHSCSR0wnlBBfRXJL5SbWxo3FQ==
 
-lodash.find@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
-  integrity sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==
-
 lodash.flatten@^4.2.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==
 
-lodash.foreach@^4.3.0, lodash.foreach@^4.5.0:
+lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
   integrity sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ==
-
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
-
-lodash.intersection@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.intersection/-/lodash.intersection-4.4.0.tgz#0a11ba631d0e95c23c7f2f4cbb9a692ed178e705"
-  integrity sha512-N+L0cCfnqMv6mxXtSPeKt+IavbOBBSiAEkKyLasZ8BVcP9YXQgxLO12oPR8OyURwKV8l5vJKiE1M8aS70heuMg==
-
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
-
-lodash.isobject@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
-  integrity sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==
 
 lodash.map@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
   integrity sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==
-
-lodash.matches@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.matches/-/lodash.matches-4.6.0.tgz#ae1affba8047f02368905fe585376bd2c10aaf5e"
-  integrity sha512-itQFfvxQETfkYkqZwUCvYXTSO9hyJuC/pUG3ckz8c5ioDR4gYfK117Bza6bKRRxB1MAX0Aezj79tqL3zINCiRA==
 
 lodash.memoize@4.x:
   version "4.1.2"
@@ -3001,12 +2951,7 @@ lodash.pick@^4.2.1:
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==
 
-lodash.range@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.range/-/lodash.range-3.2.0.tgz#f461e588f66683f7eadeade513e38a69a565a15d"
-  integrity sha512-Fgkb7SinmuzqgIhNhAElo0BL/R1rHCnhwSZf78omqSwvWqD0kD2ssOAutQonDKH/ldS8BxA72ORYI09qAY9CYg==
-
-lodash.reduce@^4.4.0, lodash.reduce@^4.6.0:
+lodash.reduce@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
   integrity sha512-6raRe2vxCYBhpBu+B+TtNGUzah+hQjVdu3E17wfusjyrXBka2nBS8OH/gjVZ5PvHOhWmIZTYri09Z6n/QfnNMw==
@@ -3020,11 +2965,6 @@ lodash.some@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
   integrity sha512-j7MJE+TuT51q9ggt4fSgVqro163BEFjAt3u97IqU+JA2DkWl80nFTrowzLpZ/BnpN7rrl0JA/593NAdd8p/scQ==
-
-lodash.transform@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.transform/-/lodash.transform-4.6.0.tgz#12306422f63324aed8483d3f38332b5f670547a0"
-  integrity sha512-LO37ZnhmBVx0GvOU/caQuipEh4GN82TcWv3yHlebGDgOxbxiwwzW5Pcx2AcvpIv2WmvmSMoC492yQFNhy/l/UQ==
 
 lodash.truncate@^4.4.2:
   version "4.4.2"
@@ -3171,11 +3111,6 @@ mocha@^10.1.0:
     yargs "16.2.0"
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
-
-mongo-objectid@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/mongo-objectid/-/mongo-objectid-1.2.2.tgz#1905eefca5c068b3bcb06685aed92ab201a243a4"
-  integrity sha512-tgpARlHojuPmCIr+NFke8iShAH342zqpG7H3bUTXImj8z9eOtsGYcgneeFKDLsrlIi/ZJi9r18Wsr1dSwTLlWQ==
 
 ms@2.1.2:
   version "2.1.2"
@@ -3392,6 +3327,11 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
+picodb@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/picodb/-/picodb-1.0.5.tgz#4c0e6e9ad3cee0d756938d7c513067d37ff10e2e"
+  integrity sha512-OCuuJscQOBqsQpNhfmpKVrOc3gISWDW68RMoJFewgHkRvS/UZq7AD3Qh57yWMV51WbzOxkTy4nO96tXMXof18g==
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
@@ -3566,23 +3506,6 @@ safe-regex-test@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.3"
     is-regex "^1.1.4"
-
-sbtree@^4.0.0-beta.1:
-  version "4.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/sbtree/-/sbtree-4.0.0-beta.1.tgz#5f99338e1abff209c4ae28c98c7893aa473eb6c7"
-  integrity sha512-rdQFk9qlWfMja2Xgbinvobo+Snb/tmjLHt6FQk9l64jtJxegiHrlvmZE+w90yhis4b2TmVoCLy/CG2bxKfHVvQ==
-  dependencies:
-    fslockjs "^3.0.0"
-    lodash.clonedeep "^4.5.0"
-    lodash.foreach "^4.5.0"
-    lodash.get "^4.4.2"
-    lodash.intersection "^4.4.0"
-    lodash.isequal "^4.5.0"
-    lodash.isobject "^3.0.2"
-    lodash.range "^3.2.0"
-    lodash.reduce "^4.6.0"
-    lodash.transform "^4.6.0"
-    mongo-objectid "^1.2.2"
 
 semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
@@ -3961,21 +3884,6 @@ typescript@^4.8.4:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
-tyrdb@^4.0.0-beta.1:
-  version "4.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/tyrdb/-/tyrdb-4.0.0-beta.1.tgz#2dc892c235c8e08e7f42624044a9876172a6a889"
-  integrity sha512-NvJ+s+Eqc/4M/MYKg/HWgQRd/AwPxZan7LIQqZF4GV0lOczt04SrJNBrywvhWg7syIYDAhjbjnD3cH6RUqTnsw==
-  dependencies:
-    eventemitter2 "^6.4.9"
-    fslockjs "^3.0.0"
-    lodash.clone "^4.5.0"
-    lodash.find "^4.6.0"
-    lodash.foreach "^4.5.0"
-    lodash.matches "^4.6.0"
-    lodash.reduce "^4.6.0"
-    mongo-objectid "^1.2.2"
-    sbtree "^4.0.0-beta.1"
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
1. We now use picoDB internally instead of having arrays ourselves.
2. This means all our existing functions now return promises (except for `getTags` but more on that in a moment).
3. We now have a `find()` function. This one will accept a Mongo style query and return a `ContentItem[]`. Eventually, we might remove most other methods as one can just use `find`  now.

### `getTags`

`getTags` continues to return a list of tag strings for now; but I'm noodling on a better collection system which would let folks define and operate their own collections (beyond just pages, posts, and tags). Once I have clarity on that topic, getTags will most likely get removed.

