### PR TITLE
Ad-Hoc Content Items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akshat1/patrika",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Patrika is a static site generator. It reads markdown files and generates a static website using a user supplied `renderToString(ContentItem, Patrika) => Promise<string | string[]>` function. Patrika is minimal and framework agnostic, meant to be used with your favorite front-end framework.",
   "main": "lib/index.js",
   "repository": "git@github.com:akshat1/patrika.git",

--- a/src/GetExtraContentItems.ts
+++ b/src/GetExtraContentItems.ts
@@ -1,0 +1,10 @@
+import { ContentItem } from "./ContentItem.js";
+import { Patrika } from "./Patrika.js";
+
+/**
+ * For tags, categories, etc.
+ * These won't go through the fileWalker function (which calls various callbacks to build ContentItems from markdown
+ * files). `args.getExtraContentItems` must provide the fully fleshed out ContentItem as per the expectations of the
+ * rendering code (i.e. `args.renderAllMarkdown`).
+ */
+export type getExtraContentItems = (patrika: Patrika) => Promise<ContentItem[]>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { getLogger } from "@akshat1/js-logger";
 import PicoDB from "picodb";
 import { ContentItem } from "./ContentItem.js";
+import { getExtraContentItems } from "./GetExtraContentItems.js";
 import { GetSlug } from "./GetSlug.js";
 import { GetURLRelativeToRoot } from "./GetURLRelativeToRoot.js";
 import { Patrika } from "./Patrika.js";
@@ -25,6 +26,7 @@ export interface GetPatrikaArgs {
   getSlug: GetSlug;
   getURLRelativeToRoot: GetURLRelativeToRoot;
   outDir: string;
+  getExtraContentItems?: getExtraContentItems;
 }
 export const getPatrika = async (args: GetPatrikaArgs): Promise<Patrika> => {
   logger.debug(args);
@@ -49,6 +51,12 @@ export const getPatrika = async (args: GetPatrikaArgs): Promise<Patrika> => {
     find: (query?: Record<string, unknown>, projection?: Record<string, unknown>) => db.find(query, projection).toArray(),
     _db: db,
   };
+
+  // Add extra content items (for things like tags, categories, etc).
+  if (typeof args.getExtraContentItems === "function") {
+    const extraItems = await args.getExtraContentItems(patrika);
+    db.insertMany(extraItems);
+  }
 
   // Render all markdown.
   await renderAllMarkdown({

--- a/src/runner/Template.ts
+++ b/src/runner/Template.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 import path from "node:path";
 import { getLogger } from "@akshat1/js-logger";
+import { getExtraContentItems } from "../GetExtraContentItems.js";
 import { GetSlug } from "../GetSlug.js";
 import { GetURLRelativeToRoot } from "../GetURLRelativeToRoot.js";
 import { RenderToString } from "../RenderToString.js";
@@ -14,6 +15,7 @@ export interface Template {
   getURLRelativeToRoot: GetURLRelativeToRoot;
   getConfig: () => RunnerConfiguration;
   onShortCode?: OnShortCode;
+  getExtraContentItems?: getExtraContentItems;
 };
 
 const rootLogger = getLogger("Template");

--- a/src/runner/worker.ts
+++ b/src/runner/worker.ts
@@ -43,7 +43,8 @@ const workerMain = async () => {
     getSlug,
     getURLRelativeToRoot,
     onShortCode,
-    renderToString
+    renderToString,
+    getExtraContentItems,
   } = template;
   const {
     contentGlob,
@@ -58,6 +59,7 @@ const workerMain = async () => {
     getURLRelativeToRoot,
     onShortCode,
     outDir,
+    getExtraContentItems,
   });
 
   logger.debug("Build everything...");


### PR DESCRIPTION
Not all pages on a website correspond to a physical markdown file. For instance, a user may wish to have an HTML page for each tag in use on the site. This can not be comfortably serviced by creating a blank markdown file for each tag.

To address this gap, this update introduces another function in `GetPatrikaArgs` with the following API

```TS
/**
 * For tags, categories, etc.
 * These won't go through the fileWalker function (which calls various callbacks to build ContentItems
 * from markdown files). `args.getExtraContentItems` must provide the fully fleshed out ContentItem as
 * per the expectations of the rendering code (i.e. `args.renderAllMarkdown`).
 */
export type getExtraContentItems = (patrika: Patrika) => Promise<ContentItem[]>;
```

Here's an example of this function in use

```TS
const getExtraContentItems = async (patrika: Patrika) : Promise<ContentItem[]> => {
  const logger = getLogger("getExtraContentItems");
  const allItems = await patrika.find();
  const tagSet = new Set<string>();
  allItems.forEach(({ frontMatter }) => {
    if (Array.isArray(frontMatter.tags)) {
      frontMatter.tags.forEach(tag => tagSet.add(tag));
    }
  });

  logger.debug(`Found tags: ${Array.from(tagSet.values()).join(", ")}`);
  return Array.from(tagSet.values()).map((tag: string): ContentItem => {
    const id = `tag-${tag.toLowerCase()}`;
    const title = tag;
    const slug = slugify(title);
    const publishDate = new Date();
    const url = `/tags/${slug}/index.html`;
    const filePath = path.join(config.outDir, url);
    logger.debug(`Creating tag page for ${tag} at ${url}, to be placed at ${filePath}`);
    return {
      markdown: "",
      url,
      sourceFilePath: "",
      filePath,
      slug,
      id,
      title,
      publishDate,
      frontMatter: {
        id,
        title,
        type: "page",
        publishDate,
        subType: "tag",
        tagName: tag,
      },
    };
  });
};
```

Normally, Patrika reads markdown files and constructs `ContentItem` objects. But this optional function let's the user supply a list of `ContentItem` objects which may or may not correspond to anything on the disk.

### Future

This API is going to evolve. I'm most probably going to rename this function, and change things around so that one may supply either the globs (for markdown files), or this function, or both. That will make markdown optional as well (so that someone may choose to fetch data from an API for instance). Not doing it immediately because that raises the further question of what Patrika is (because the renderer is user supplied, and if ContentItems are also user supplied than why do we need Patrika?). As always, need to balance flexibility with utility. Needs more thought.
